### PR TITLE
feat: add option to pull docker compose image

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Example 1: Deploy using Docker Stack
       - name: Deploy using Docker Stack
         uses: alcharra/docker-deploy-action-go@v1
         with:
@@ -223,6 +224,7 @@ jobs:
           registry_user: ${{ github.actor }}
           registry_pass: ${{ secrets.GITHUB_TOKEN }}
 
+      # Example 2: Deploy using Docker Compose
       - name: Deploy using Docker Compose
         uses: alcharra/docker-deploy-action-go@v1
         with:

--- a/README.md
+++ b/README.md
@@ -50,29 +50,30 @@ This speed gain comes from running a single compiled binary without shell overhe
 
 ## Inputs
 
-| Input Parameter             | Description                                                                 | Required | Default Value        |
-| --------------------------- | --------------------------------------------------------------------------- | :------: | -------------------- |
-| `ssh_host`                  | Hostname or IP address of the target server                                 |    ✅    |                      |
-| `ssh_port`                  | Port used for the SSH connection                                            |    ❌    | `22`                 |
-| `ssh_user`                  | Username used for the SSH connection                                        |    ✅    |                      |
-| `ssh_key`                   | Private SSH key for authentication                                          |    ✅    |                      |
-| `ssh_key_passphrase`        | Passphrase for the encrypted SSH private key                                |    ❌    |                      |
-| `ssh_known_hosts`           | Contents of the SSH `known_hosts` file used to verify the server's identity |    ❌    |                      |
-| `fingerprint`               | SSH host fingerprint for verifying the server's identity (SHA256 format)    |    ❌    |                      |
-| `timeout`                   | SSH connection timeout (e.g. `10s`, `30s`, `1m`)                            |    ❌    | `10s`                |
-| `project_path`              | Path on the server where files will be uploaded                             |    ✅    |                      |
-| `deploy_file`               | Path to the file used for defining the deployment (e.g. Docker Compose)     |    ✅    | `docker-compose.yml` |
-| `extra_files`               | Additional files to upload (e.g. `.env`, config files)                      |    ❌    |                      |
-| `mode`                      | Deployment mode (`compose` or `stack`)                                      |    ❌    | `compose`            |
-| `stack_name`                | Stack name used during Swarm deployment (required if mode is `stack`)       |    ❌    |                      |
-| `docker_network`            | Name of the Docker network to be used or created if missing                 |    ❌    |                      |
-| `docker_network_driver`     | Driver for the network (`bridge`, `overlay`, `macvlan`, etc.)               |    ❌    | `bridge`             |
-| `docker_network_attachable` | Whether standalone containers can attach to the network (`true` / `false`)  |    ❌    | `false`              |
-| `docker_prune`              | Type of Docker resource prune to run after deployment                       |    ❌    | `none`               |
-| `registry_host`             | Host address for the registry or remote service requiring authentication    |    ❌    |                      |
-| `registry_user`             | Username for authenticating with the registry or remote service             |    ❌    |                      |
-| `registry_pass`             | Password or token for authenticating with the registry or remote service    |    ❌    |                      |
-| `enable_rollback`           | Whether to enable automatic rollback if deployment fails (`true` / `false`) |    ❌    | `false`              |
+| Input Parameter             | Description                                                                                          | Required | Default Value        |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- | :------: | -------------------- |
+| `ssh_host`                  | Hostname or IP address of the target server                                                          |    ✅    |                      |
+| `ssh_port`                  | Port used for the SSH connection                                                                     |    ❌    | `22`                 |
+| `ssh_user`                  | Username used for the SSH connection                                                                 |    ✅    |                      |
+| `ssh_key`                   | Private SSH key for authentication                                                                   |    ✅    |                      |
+| `ssh_key_passphrase`        | Passphrase for the encrypted SSH private key                                                         |    ❌    |                      |
+| `ssh_known_hosts`           | Contents of the SSH `known_hosts` file used to verify the server's identity                          |    ❌    |                      |
+| `fingerprint`               | SSH host fingerprint for verifying the server's identity (SHA256 format)                             |    ❌    |                      |
+| `timeout`                   | SSH connection timeout (e.g. `10s`, `30s`, `1m`)                                                     |    ❌    | `10s`                |
+| `project_path`              | Path on the server where files will be uploaded                                                      |    ✅    |                      |
+| `deploy_file`               | Path to the file used for defining the deployment (e.g. Docker Compose)                              |    ✅    | `docker-compose.yml` |
+| `extra_files`               | Additional files to upload (e.g. `.env`, config files)                                               |    ❌    |                      |
+| `mode`                      | Deployment mode (`compose` or `stack`)                                                               |    ❌    | `compose`            |
+| `stack_name`                | Stack name used during Swarm deployment (required if mode is `stack`)                                |    ❌    |                      |
+| `compose_pull`              | Whether to pull the latest images before bringing up services with Docker Compose (`true` / `false`) |    ❌    | `true`               |
+| `docker_network`            | Name of the Docker network to be used or created if missing                                          |    ❌    |                      |
+| `docker_network_driver`     | Driver for the network (`bridge`, `overlay`, `macvlan`, etc.)                                        |    ❌    | `bridge`             |
+| `docker_network_attachable` | Whether standalone containers can attach to the network (`true` / `false`)                           |    ❌    | `false`              |
+| `docker_prune`              | Type of Docker resource prune to run after deployment                                                |    ❌    | `none`               |
+| `registry_host`             | Host address for the registry or remote service requiring authentication                             |    ❌    |                      |
+| `registry_user`             | Username for authenticating with the registry or remote service                                      |    ❌    |                      |
+| `registry_pass`             | Password or token for authenticating with the registry or remote service                             |    ❌    |                      |
+| `enable_rollback`           | Whether to enable automatic rollback if deployment fails (`true` / `false`)                          |    ❌    | `false`              |
 
 ## SSH Host Key Verification
 
@@ -188,39 +189,73 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Example 1: Deploy to Docker Swarm
-      - name: Deploy to Docker Swarm
+      - name: Deploy using Docker Stack
         uses: alcharra/docker-deploy-action-go@v1
         with:
-          ssh_host: ${{ secrets.SSH_HOST }}
-          ssh_user: ${{ secrets.SSH_USER }}
-          ssh_key: ${{ secrets.SSH_KEY }}
-          project_path: /opt/myapp
-          deploy_file: docker-stack.yml
-          extra_files: .env,traefik.yml
-          mode: stack
-          stack_name: myapp
-          docker_network: myapp_network
-          docker_network_driver: overlay
-          docker_prune: system
+          # Required SSH configuration
+          ssh_host: ${{ secrets.SSH_HOST }}              # Hostname or IP address of the target server
+          ssh_user: ${{ secrets.SSH_USER }}              # SSH username
+          ssh_key: ${{ secrets.SSH_KEY }}                # Private SSH key for authentication
+          project_path: /opt/myapp                       # Remote path where project files will be uploaded
+
+          # Deployment configuration
+          deploy_file: docker-stack.yml                  # Path to the Docker Stack file
+          mode: stack                                    # Deployment mode
+          stack_name: myapp                              # Name of the Docker stack to deploy
+
+          # Optional SSH security settings
+          ssh_key_passphrase: ${{ secrets.SSH_KEY_PASSPHRASE }}   # Passphrase for the SSH key, if encrypted
+          ssh_known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}         # SSH known_hosts contents to verify server identity
+          fingerprint: ${{ secrets.SSH_FINGERPRINT }}             # SSH host fingerprint for additional verification
+
+          # Additional files to include in the deployment
+          extra_files: traefik.yml                  # Comma-separated list of extra files to upload
+
+          # Docker network configuration
+          docker_network: myapp_network                  # Name of the Docker network to use
+          docker_network_driver: overlay                 # Driver for the Docker network
+
+          # Cleanup after deployment
+          docker_prune: system                           # Type of Docker prune to perform
+
+          # Registry authentication (for pulling private images)
           registry_host: ghcr.io
           registry_user: ${{ github.actor }}
           registry_pass: ${{ secrets.GITHUB_TOKEN }}
 
-      # Example 2: Deploy using Docker Compose
       - name: Deploy using Docker Compose
         uses: alcharra/docker-deploy-action-go@v1
         with:
-          ssh_host: ${{ secrets.SSH_HOST }}
-          ssh_user: ${{ secrets.SSH_USER }}
-          ssh_key: ${{ secrets.SSH_KEY }}
-          project_path: /opt/myapp
-          deploy_file: docker-compose.yml
-          extra_files: .env,database.env,nginx.conf
-          mode: compose
-          docker_network: myapp_network
-          docker_network_driver: bridge
-          docker_prune: system
+          # Required SSH configuration
+          ssh_host: ${{ secrets.SSH_HOST }}              # Hostname or IP address of the target server
+          ssh_user: ${{ secrets.SSH_USER }}              # SSH username
+          ssh_key: ${{ secrets.SSH_KEY }}                # Private SSH key for authentication
+          project_path: /opt/myapp                       # Remote path where project files will be uploaded
+
+          # Deployment configuration
+          deploy_file: docker-compose.yml                # Path to the Docker Compose file
+          mode: compose                                  # Deployment mode
+
+          # Optional SSH security settings
+          ssh_key_passphrase: ${{ secrets.SSH_KEY_PASSPHRASE }}   # Passphrase for the SSH key, if encrypted
+          ssh_known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}         # SSH known_hosts contents to verify server identity
+          fingerprint: ${{ secrets.SSH_FINGERPRINT }}             # SSH host fingerprint for additional verification
+
+          # Additional files to include in the deployment
+          extra_files: .env,database.env,nginx.conf      # Comma-separated list of extra files to upload
+
+          # Deployment behaviour
+          compose_pull: true                             # Pull the latest images before starting services
+          enable_rollback: true                          # Enable rollback if deployment fails
+
+          # Docker network configuration
+          docker_network: myapp_network                  # Name of the Docker network to use
+          docker_network_driver: bridge                  # Driver for the Docker network
+
+          # Cleanup after deployment
+          docker_prune: system                           # Type of Docker prune to perform
+
+          # Registry authentication (for pulling private images)
           registry_host: docker.io
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
   stack_name:
     description: "The name of the stack to deploy (required if mode is set to 'stack')."
     required: false
+  compose_pull:
+    description: "Whether to pull the latest images before bringing up services with Docker Compose (true/false)."
+    required: false
+    default: "true"
   docker_network:
     description: "The name of the network to be used for deployment (created if it does not exist)."
     required: false
@@ -101,6 +105,7 @@ runs:
         DOCKER_PRUNE: ${{ inputs.docker_prune }}
         MODE: ${{ inputs.mode }}
         STACK_NAME: ${{ inputs.stack_name }}
+        COMPOSE_PULL: ${{ inputs.compose_pull }}
         DOCKER_NETWORK: ${{ inputs.docker_network }}
         DOCKER_NETWORK_DRIVER: ${{ inputs.docker_network_driver }}
         DOCKER_NETWORK_ATTACHABLE: ${{ inputs.docker_network_attachable }}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ func LoadConfig() DeployConfig {
 		ExtraFiles:          splitEnv("EXTRA_FILES"),
 		Mode:                getEnv("MODE", "compose"),
 		StackName:           getEnv("STACK_NAME", ""),
+		ComposePull:         getEnv("COMPOSE_PULL", "true") == "true",
 		DockerNetwork:       getEnv("DOCKER_NETWORK", ""),
 		DockerNetworkDriver: getEnv("DOCKER_NETWORK_DRIVER", "bridge"),
 		DockerNetworkAttach: getEnv("DOCKER_NETWORK_ATTACHABLE", "false") == "true",

--- a/config/types.go
+++ b/config/types.go
@@ -14,6 +14,7 @@ type DeployConfig struct {
 	ExtraFiles          []string
 	Mode                string
 	StackName           string
+	ComposePull         bool
 	DockerNetwork       string
 	DockerNetworkDriver string
 	DockerNetworkAttach bool

--- a/deploy/docker/compose.go
+++ b/deploy/docker/compose.go
@@ -18,6 +18,7 @@ func DeployDockerCompose(client *ssh.Client, cfg config.DeployConfig) {
 	cmd := fmt.Sprintf(`
 		PROJECT_PATH="%s"
 		ENABLE_ROLLBACK="%t"
+		COMPOSE_PULL="%t"
 
 		echo "🐳 Deploying using Docker Compose"
 
@@ -32,7 +33,12 @@ func DeployDockerCompose(client *ssh.Client, cfg config.DeployConfig) {
 
 		cd "$PROJECT_PATH" || { echo "❌ Failed to cd into $PROJECT_PATH"; exit 1; }
 
-		$COMPOSE pull &&
+		if [ "$COMPOSE_PULL" = "true" ]; then
+			$COMPOSE pull || { echo "❌ Failed to pull images"; exit 1; }
+		else
+			echo "⏩ Skipping image pull"
+		fi
+
 		$COMPOSE down &&
 		$COMPOSE up -d
 
@@ -68,11 +74,11 @@ func DeployDockerCompose(client *ssh.Client, cfg config.DeployConfig) {
 			else
 				echo "⚠️ Rollback is disabled"
 			fi
-		exit 1
+			exit 1
 		else
 			echo "✅ All services are running"
 		fi
-	`, projectPath, cfg.EnableRollback)
+	`, projectPath, cfg.EnableRollback, cfg.ComposePull)
 
 	err := client.RunCommandStreamed(cmd)
 	if err != nil {


### PR DESCRIPTION
### 🚀 Summary of Changes

- Added support for controlling image pulls via a new `compose_pull` input.
- Users can now choose whether to pull the latest Docker images during Compose deployments, allowing for faster or more controlled rollouts.
- Improved README documentation with clear, professional deployment examples for both Docker Compose and Docker Stack.
