### PR TITLE
feat: add support for list/map syntax and improve validation flexibility

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,8 @@ set -o nounset
 set -o pipefail
 
 REPO="alcharra/docker-deploy-action-go"
-RELEASE_VERSION="${RELEASE_VERSION:-v2.0.0}"
+LATEST_VERSION="v2.0.1"
+RELEASE_VERSION="${RELEASE_VERSION:-$LATEST_VERSION}"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH_RAW="$(uname -m)"
 ARCH="$ARCH_RAW"
@@ -40,7 +41,7 @@ echo -e "\U0001F9F0 Extracting binary..."
 tar -xzf "$ARCHIVE"
 chmod +x docker-deploy-action-go*
 
-echo -e "\U0001F680 Running docker-deploy-action-go version $RELEASE_VERSION..."
+echo -e "\U0001F680 Running docker-deploy-action-go version $LATEST_VERSION..."
 ./docker-deploy-action-go* "$@"
 
 rm "$ARCHIVE"

--- a/internal/validator/helpers.go
+++ b/internal/validator/helpers.go
@@ -1,0 +1,10 @@
+package validator
+
+import "strings"
+
+func isBindMount(name string) bool {
+	return strings.HasPrefix(name, "./") ||
+		strings.HasPrefix(name, "/") ||
+		strings.HasPrefix(name, "../") ||
+		strings.HasPrefix(name, "~")
+}

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -9,15 +9,21 @@ type ComposeFile struct {
 	Secrets  map[string]*SecretDefinition  `yaml:"secrets,omitempty"`
 }
 
+type StringMap map[string]string
+
 type ServiceDefinition struct {
-	Image   string            `yaml:"image"`
-	Build   interface{}       `yaml:"build,omitempty"`
-	Env     map[string]string `yaml:"environment,omitempty"`
-	Configs []ConfigReference `yaml:"configs,omitempty"`
-	Secrets []SecretReference `yaml:"secrets,omitempty"`
-	Deploy  *DeployDefinition `yaml:"deploy,omitempty"`
-	Ports   []interface{}     `yaml:"ports,omitempty"`
-	Command interface{}       `yaml:"command,omitempty"`
+	Image      string            `yaml:"image"`
+	Build      interface{}       `yaml:"build,omitempty"`
+	Env        StringMap         `yaml:"environment,omitempty"`
+	Labels     StringMap         `yaml:"labels,omitempty"`
+	Configs    []ConfigReference `yaml:"configs,omitempty"`
+	Secrets    []SecretReference `yaml:"secrets,omitempty"`
+	Deploy     *DeployDefinition `yaml:"deploy,omitempty"`
+	Ports      []interface{}     `yaml:"ports,omitempty"`
+	Command    interface{}       `yaml:"command,omitempty"`
+	Entrypoint interface{}       `yaml:"entrypoint,omitempty"`
+	Volumes    []interface{}     `yaml:"volumes,omitempty"`
+	Networks   []interface{}     `yaml:"networks,omitempty"`
 }
 
 type DeployDefinition struct {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -76,6 +76,20 @@ func (c *ComposeFile) Validate() error {
 		default:
 			errs = append(errs, fmt.Sprintf("service '%s' command must be a string or list of strings", name))
 		}
+
+		switch ep := svc.Entrypoint.(type) {
+		case string:
+		case []interface{}:
+			for i, part := range ep {
+				if _, ok := part.(string); !ok {
+					errs = append(errs, fmt.Sprintf("service '%s' entrypoint[%d] must be a string", name, i))
+				}
+			}
+		case nil:
+		default:
+			errs = append(errs, fmt.Sprintf("service '%s' entrypoint must be a string or list of strings", name))
+		}
+
 		for _, ref := range svc.Configs {
 			if ref.Source == "" {
 				errs = append(errs, fmt.Sprintf("service '%s' references a config with no 'source'", name))
@@ -88,6 +102,47 @@ func (c *ComposeFile) Validate() error {
 				errs = append(errs, fmt.Sprintf("service '%s' references a secret with no 'source'", name))
 			} else if c.Secrets == nil || c.Secrets[ref.Source] == nil {
 				errs = append(errs, fmt.Sprintf("service '%s' references undefined secret '%s'", name, ref.Source))
+			}
+		}
+
+		for i, v := range svc.Volumes {
+			switch val := v.(type) {
+			case string:
+				volumeName := strings.SplitN(val, ":", 2)[0]
+				if !isBindMount(volumeName) {
+					if _, ok := c.Volumes[volumeName]; !ok {
+						errs = append(errs, fmt.Sprintf("service '%s' uses undefined volume '%s'", name, volumeName))
+					}
+				}
+			case map[string]interface{}:
+				if src, ok := val["source"].(string); ok {
+					if _, ok := c.Volumes[src]; !ok {
+						errs = append(errs, fmt.Sprintf("service '%s' uses undefined volume '%s'", name, src))
+					}
+				} else {
+					errs = append(errs, fmt.Sprintf("service '%s' volumes[%d] missing or invalid 'source'", name, i))
+				}
+			default:
+				errs = append(errs, fmt.Sprintf("service '%s' volumes[%d] must be string or map with 'source'", name, i))
+			}
+		}
+
+		for i, n := range svc.Networks {
+			switch val := n.(type) {
+			case string:
+				if _, ok := c.Networks[val]; !ok {
+					errs = append(errs, fmt.Sprintf("service '%s' uses undefined network '%s'", name, val))
+				}
+			case map[string]interface{}:
+				if nameVal, ok := val["name"].(string); ok {
+					if _, ok := c.Networks[nameVal]; !ok {
+						errs = append(errs, fmt.Sprintf("service '%s' uses undefined network '%s'", name, nameVal))
+					}
+				} else {
+					errs = append(errs, fmt.Sprintf("service '%s' networks[%d] missing or invalid 'name'", name, i))
+				}
+			default:
+				errs = append(errs, fmt.Sprintf("service '%s' networks[%d] must be string or map with 'name'", name, i))
 			}
 		}
 	}
@@ -125,5 +180,35 @@ func (c *ComposeFile) Validate() error {
 		return errors.New("validation failed:\n      \u2192 " + strings.Join(errs, "\n      \u2192 "))
 	}
 
+	return nil
+}
+
+func (sm *StringMap) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.MappingNode:
+		var m map[string]string
+		if err := value.Decode(&m); err != nil {
+			return fmt.Errorf("invalid map: %w", err)
+		}
+		*sm = m
+
+	case yaml.SequenceNode:
+		m := make(map[string]string)
+		for _, item := range value.Content {
+			var pair string
+			if err := item.Decode(&pair); err != nil {
+				return fmt.Errorf("invalid list item: %w", err)
+			}
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid format (expected KEY=VALUE): %s", pair)
+			}
+			m[parts[0]] = parts[1]
+		}
+		*sm = m
+
+	default:
+		return fmt.Errorf("must be a map or list of KEY=VALUE strings")
+	}
 	return nil
 }

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1,0 +1,448 @@
+//go:build unit
+// +build unit
+
+package validator
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateComposeWithBindMountsAndEnv(t *testing.T) {
+	yamlContent := `
+services:
+  web:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8080:80"
+    networks:
+      - test_network_stack
+
+  redis:
+    image: redis:latest
+    volumes:
+      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    networks:
+      - test_network_stack
+
+  db:
+    image: postgres:latest
+    environment:
+      - POSTGRES_DB=mydb
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    networks:
+      - test_network_stack
+
+volumes:
+  db_data: {}
+
+networks:
+  test_network_stack:
+    driver: overlay
+`
+
+	os.Setenv("POSTGRES_DB", "mydb")
+	os.Setenv("POSTGRES_USER", "admin")
+	os.Setenv("POSTGRES_PASSWORD", "secret")
+
+	content := os.ExpandEnv(yamlContent)
+
+	var cfg ComposeFile
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("Validation failed unexpectedly:\n%s", err)
+	}
+}
+
+func loadAndValidateYAML(t *testing.T, yamlContent string) error {
+	content := os.ExpandEnv(yamlContent)
+
+	var cfg ComposeFile
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	return cfg.Validate()
+}
+
+func TestValidComposeFile(t *testing.T) {
+	yaml := `
+services:
+  web:
+    image: nginx
+    volumes:
+      - ./site:/usr/share/nginx/html
+    ports:
+      - "8080:80"
+    networks:
+      - net1
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD=secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - net1
+volumes:
+  pgdata: {}
+networks:
+  net1: {}
+`
+	if err := loadAndValidateYAML(t, yaml); err != nil {
+		t.Errorf("Expected valid Compose file, got error: %v", err)
+	}
+}
+
+func TestMissingImage(t *testing.T) {
+	yaml := `
+services:
+  bad:
+    ports:
+      - "1234:80"
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "missing 'image'") {
+		t.Errorf("Expected error about missing image, got: %v", err)
+	}
+}
+
+func TestUnsupportedBuildDirective(t *testing.T) {
+	yaml := `
+services:
+  app:
+    build: .
+    image: myapp
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "uses 'build'") {
+		t.Errorf("Expected error for 'build', got: %v", err)
+	}
+}
+
+func TestInvalidPortFormat(t *testing.T) {
+	yaml := `
+services:
+  web:
+    image: nginx
+    ports:
+      - "8080"
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "must contain at least one ':'") {
+		t.Errorf("Expected port format error, got: %v", err)
+	}
+}
+
+func TestInvalidCommandListType(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: busybox
+    command: ["echo", 123]
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "command[1] must be a string") {
+		t.Errorf("Expected command list string error, got: %v", err)
+	}
+}
+
+func TestInvalidEntrypointListType(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: busybox
+    entrypoint: ["run.sh", 42]
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "entrypoint[1] must be a string") {
+		t.Errorf("Expected entrypoint list string error, got: %v", err)
+	}
+}
+
+func TestUndefinedVolumeReference(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    volumes:
+      - myvolume:/data
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "uses undefined volume") {
+		t.Errorf("Expected undefined volume error, got: %v", err)
+	}
+}
+
+func TestUndefinedNetworkReference(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    networks:
+      - ghostnet
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "uses undefined network") {
+		t.Errorf("Expected undefined network error, got: %v", err)
+	}
+}
+
+func TestInvalidDeployReplicas(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    deploy:
+      replicas: 0
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "must be >= 1") {
+		t.Errorf("Expected replicas >= 1 error, got: %v", err)
+	}
+}
+
+func TestInvalidConstraintSyntax(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    deploy:
+      placement:
+        constraints:
+          - node.role=manager
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "must contain '==' or '!='") {
+		t.Errorf("Expected constraint syntax error, got: %v", err)
+	}
+}
+
+func TestInvalidPortType(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    ports:
+      - 8080
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "must be a string") {
+		t.Errorf("Expected port type error, got: %v", err)
+	}
+}
+
+func TestVolumeMapMissingSource(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    volumes:
+      - { target: /data }
+volumes:
+  vol: {}
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "missing or invalid 'source'") {
+		t.Errorf("Expected volume map missing source error, got: %v", err)
+	}
+}
+
+func TestNetworkMapMissingName(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    networks:
+      - { driver: bridge }
+networks:
+  net1: {}
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "missing or invalid 'name'") {
+		t.Errorf("Expected network map missing name error, got: %v", err)
+	}
+}
+
+func TestConfigReferenceMissingSource(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    configs:
+      - target: /app/config
+configs:
+  myconfig:
+    file: ./config.yaml
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "config with no 'source'") {
+		t.Errorf("Expected config missing source error, got: %v", err)
+	}
+}
+
+func TestUndefinedSecretReference(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    secrets:
+      - source: missing_secret
+secrets:
+  real_secret:
+    file: ./secret.txt
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "references undefined secret") {
+		t.Errorf("Expected undefined secret error, got: %v", err)
+	}
+}
+
+func TestInvalidExternalFieldType(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+
+volumes:
+  badvol:
+    external: "yes"
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "invalid 'external' value") {
+		t.Errorf("Expected invalid external value error, got: %v", err)
+	}
+}
+
+func TestValidVolumeWithExternalMap(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    volumes:
+      - myvol:/data
+volumes:
+  myvol:
+    driver: local
+    external:
+      name: external_vol
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err != nil {
+		t.Errorf("Expected valid external volume map, got: %v", err)
+	}
+}
+
+func TestEmptyServicesBlock(t *testing.T) {
+	yaml := `
+services: {}
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "no services defined") {
+		t.Errorf("Expected error about no services, got: %v", err)
+	}
+}
+
+func TestSecretReferenceMissingSource(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    secrets:
+      - target: /run/secrets/password
+secrets:
+  mysecret:
+    file: ./secret.txt
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err == nil || !strings.Contains(err.Error(), "secret with no 'source'") {
+		t.Errorf("Expected secret missing source error, got: %v", err)
+	}
+}
+
+func TestEnvironmentAsMap(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: postgres
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: secret
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err != nil {
+		t.Errorf("Expected valid environment map, got: %v", err)
+	}
+}
+
+func TestLabelsAsList(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    labels:
+      - "com.example.description=web app"
+      - "com.example.version=1.0"
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err != nil {
+		t.Errorf("Expected valid labels list, got: %v", err)
+	}
+}
+
+func TestLabelsAsMap(t *testing.T) {
+	yaml := `
+services:
+  app:
+    image: nginx
+    labels:
+      com.example.description: "web app"
+      com.example.version: "1.0"
+`
+	err := loadAndValidateYAML(t, yaml)
+	if err != nil {
+		t.Errorf("Expected valid labels map, got: %v", err)
+	}
+}
+
+func TestIsBindMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"relative path", "./data:/path", true},
+		{"absolute path", "/data:/path", true},
+		{"parent dir", "../data:/path", true},
+		{"home dir", "~/data:/path", true},
+		{"named volume", "myvolume:/path", false},
+		{"named volume with options", "data:/path:ro", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			volume := strings.SplitN(tt.input, ":", 2)[0]
+			got := isBindMount(volume)
+			if got != tt.expected {
+				t.Errorf("isBindMount(%q) = %v, expected %v", volume, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 🚀 Summary of Changes

- Added support for both list and map formats in `environment`, `labels`, `volumes`, and `networks` fields
- Improved validation logic, including:
  - Minimum check for `deploy.replicas`
  - Type checking for `ports`, `command`, and `entrypoint`
  - Validation of service references to top-level `volumes`, `networks`, `configs`, and `secrets`
- Introduced extensive unit tests covering valid and invalid Compose configurations
- Improved error clarity and robustness in file validation
